### PR TITLE
moved the logic to load file duration of narrator audio files to script generator and storing it in the firestore. In the api, we retrieve that stored data

### DIFF
--- a/functions/_local_narrator_audio_gen.py
+++ b/functions/_local_narrator_audio_gen.py
@@ -1,8 +1,10 @@
 import json
 from elevenlabs_api import elevenlabs_tts
-import gcloud_text_to_speech_api as gcloud_tts
+from gcloud_text_to_speech_api import google_synthesize_text, create_google_voice
+from google.cloud import firestore
 
-narrator_voice = gcloud_tts.choose_voice('en-US', "f", "en-US-Standard-C")
+narrator_voice = create_google_voice("en-US", "en-US-Journey-F")
+narrator_file_durations = {}
 
 with open('_local_narrator_pool.json', 'r') as file:
     narrator_pool = json.load(file)
@@ -11,7 +13,13 @@ for section_key, section in narrator_pool.items():
     for key, value in section.items():
         file_name = f"{section_key}_{key}.mp3"
         # elevenlabs_tts(value, f"audio/{file_name}")
-        gcloud_tts.synthesize_text(value, narrator_voice, f"google_tts/narrator_english/{file_name}",  bucket_name="narrator_audio_files")
+        narrator_file_durations.update(google_synthesize_text(value, narrator_voice, f"google_tts/narrator_english/{file_name}",  bucket_name="narrator_audio_files"))
+narrator_file_durations.update({"one_second_break": 1.0, "five_second_break": 5.0})
+
+db = firestore.Client()
+doc_ref = db.collection('narrator_audio_files_durations/google_tts/narrator_english').document()
+doc_ref.set(narrator_file_durations, merge=True)
+
 
 # narrator_voice = "GoZIEyk9z3H2szw545o8" 
 # elevenlabs_tts("Text to generate",narrator_voice, f"audio/{"file_name"}.mp3")

--- a/functions/gcloud_text_to_speech_api.py
+++ b/functions/gcloud_text_to_speech_api.py
@@ -59,7 +59,10 @@ def google_synthesize_text(text, voice, output_path, local_run=False, bucket_nam
         # Make the blob publicly accessible
         blob.make_public()
         
-        return {output_path.split("/")[1].replace('.mp3', ''): duration}
+        if bucket_name == "conversations_audio_files":
+            return {output_path.split("/")[1].replace('.mp3', ''): duration}
+        else:
+            return {output_path.split("/")[2].replace('.mp3', ''): duration}
 
 def list_voices(language_code=None):
     client = tts.TextToSpeechClient()

--- a/functions/main.py
+++ b/functions/main.py
@@ -78,6 +78,20 @@ def full_API_workflow(req: https_fn.Request) -> https_fn.Response:
 
     # Parse chatGPT_response and store in Firebase Storage
     fileDurations = parse_and_convert_to_speech(chatGPT_response, response_db_id, TTS_PROVIDERS.GOOGLE.value, native_language, target_language, speakers, title, number_of_audio_files, words_to_repeat)
+    
+    
+        
+    # get narrator_audio_files_durations from Firestore
+    collection_name_narrator = "narrator_audio_files_durations/google_tts/narrator_english"
+    coll_ref_narrator= db.collection(collection_name_narrator)
+    
+    docs = coll_ref_narrator.stream()
+    first_doc = next(docs, None)
+    
+    if first_doc:
+        fileDurations.update(first_doc.to_dict())
+    else:
+        print("No such document!")
 
     # Create final response with link to audio files and script
     response = {}
@@ -91,20 +105,10 @@ def full_API_workflow(req: https_fn.Request) -> https_fn.Response:
     response["userID"] = user_ID
     response["fileDurations"] = fileDurations
 
-    #save script to Firestore
+    #save script to Firestore inside the chatGPT_responses document
     subcollection_ref = doc_ref.collection('scripts')
     subcollection_ref.document().set(response)
-
-    # get all the file durations from narrator_audio_files bucket metadata
-    client = storage.Client()
-    bucket = client.get_bucket("narrator_audio_files")
-    
-    for blob in bucket.list_blobs(prefix="google_tts/narrator_english"):
-        metadata = blob.metadata
-        if metadata and 'duration' in metadata:
-            fileDurations[blob.name.split('/')[2].replace('.mp3', '')] = metadata['duration']
-
-    
+ 
     return response
 
 def chatGPT_API_call(dialogue, native_language, target_language, language_level, length, speakers):


### PR DESCRIPTION
This is only implemented for google tts for now. Will create another ticket to do the same for elevenlabs